### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,14 @@
+name: Continuous Integration
+on: push
+jobs:
+  build-docker-images:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Docker images
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        if: ${{ always() && hashFiles('Dockerfile') }}
+        run: |
+          curl "https://raw.githubusercontent.com/pelias/ci-tools/master/build-docker-images.sh" | bash -


### PR DESCRIPTION
This CI needs only to build Docker images.

It's configured so that only branches with a `Dockerfile` will run CI. Since the master branch won't have one (they will all live in branches like `v7.9.1`, etc), this is helpful.