### PR TITLE
fix(v7.5.1): Reduce permission change scope to lower image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
 
 ## set permissions so any user can run elasticsearch
 # add read permissions to all files in dir
-RUN chmod go+r /usr/share/elasticsearch -R
+RUN chmod go+r /usr/share/elasticsearch/config -R
 
 # add write permissions to config, log & data dirs
 RUN chmod go+w /usr/share/elasticsearch \


### PR DESCRIPTION
While taking a look at some other Docker images recently, I noticed that the `RUN chmod go+r /usr/share/elasticsearch -R` we are running in our Elasticsearch image causes a massive 506MB increase in the final image size.

It looks like running `chmod` on a file causes the entire file to be included in that layer of the Docker image, making it a very expensive operation in terms of disk usage.

Fortunately, with some experimentation I discovered that the only permission change we _need_ to make is within a small sub-directory.

By making this change we can preserve all operation of the Docker image, but reduce its size significantly.
