### PR TITLE
Add Elasticsearch version 7.16.1 Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# see: https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
+
+# base image
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.1
+USER root
+
+# environmental settings
+ENV ES_JAVA_OPTS '-Xms512m -Xmx512m'
+ENV cluster.name 'pelias-dev'
+ENV discovery.type 'single-node'
+ENV bootstrap.memory_lock 'true'
+RUN echo 'vm.max_map_count=262144' >> /etc/sysctl.conf
+
+# configure plugins
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install repository-s3 --batch
+
+# elasticsearch config
+ADD elasticsearch.yml /usr/share/elasticsearch/config/
+RUN chown elasticsearch:elasticsearch config/elasticsearch.yml
+
+## set permissions so any user can run elasticsearch
+# add read permissions to all files in dir
+RUN chmod go+r /usr/share/elasticsearch -R
+
+# add write permissions to config, log & data dirs
+RUN chmod go+w /usr/share/elasticsearch \
+  /usr/share/elasticsearch/config \
+  /usr/share/elasticsearch/logs \
+  /usr/share/elasticsearch/data
+
+# add list permissions to directories
+RUN chmod go+x /usr/share/elasticsearch \
+  /usr/share/elasticsearch/config \
+  /usr/share/elasticsearch/config/repository-s3
+
+# add execute permissions to bins
+RUN chmod go+x /usr/share/elasticsearch/bin/*
+
+# run as elasticsearch user
+USER elasticsearch

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,0 +1,9 @@
+bootstrap.memory_lock: true
+network.host: 0.0.0.0
+http.port: 9200
+node.master: true
+node.data: true
+thread_pool:
+  write:
+    queue_size: 1000
+indices.query.bool.max_clause_count: 4000


### PR DESCRIPTION
This adds a Pelias Docker image for [Elasticsearch 7.16.1](https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-7.16.1.html)

In this new version are mitigations for the log4j security vulnerability, discussed in https://github.com/pelias/pelias/issues/921

This version of Elasticsearch has not _yet_ been fully validated for use with Pelias, but that would likely only mean there are minor performance or query result differences, since Pelias _does_ work with older versions of the 7.x line.